### PR TITLE
bump to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10408,9 +10408,9 @@
       "dev": true
     },
     "webstomp-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/webstomp-client/-/webstomp-client-1.2.0.tgz",
-      "integrity": "sha512-samQ+9i8WQJIL5BWtrsN+i3wNeZGsVwWmNFyz2n3oyMHwNrK3UpQ7nin04w9gpDjV/ZPLYIIh3cosGuXCDONSQ=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/webstomp-client/-/webstomp-client-1.2.2.tgz",
+      "integrity": "sha512-7Wb4LgsXTmb29fiHm4sXPSOPRA02+ciDDRLBI7JWOG3/lFlv+9gvcE8uPSJC6r4FRIaLCnQVApGBXuXqckVt9g=="
     },
     "when": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^6.0.3",
     "core-js": "^2.5.4",
     "rxjs": "^6.0.0",
-    "webstomp-client": "1.2.0",
+    "webstomp-client": "1.2.2",
     "zone.js": "^0.8.26"
   },
   "devDependencies": {


### PR DESCRIPTION
Just run:

```
npm i
npm start
```

and open http://localhost:4200
You should see the error in the console.

If you do the same on master (which uses `webstomp-client@1.2.0`) you'll see that there is no error.